### PR TITLE
Adding continue-on-error for README.md generation step. Warning regar…

### DIFF
--- a/.github/workflows/autodoc.yaml
+++ b/.github/workflows/autodoc.yaml
@@ -27,6 +27,7 @@ jobs:
 # For more information on Terraform-docs, visit their site: https://terraform-docs.io
     - name: README.md generation
       uses: terraform-docs/gh-actions@main
+      continue-on-error: true
       id: tfdocs
       with:
         config-file: terraform-docs.yaml


### PR DESCRIPTION
…ding soon-to-be-deprecated function is failing  step and then skipping the rest of job. Update to no longer use set-output in Terraform docs will be required soon.